### PR TITLE
Weather Level Adjustment bug fixes

### DIFF
--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -258,13 +258,18 @@ def get_data(suffix, name=None, force=False):
             else:
                 raise Exception('JSON decoding failed.')
 
+            # If we made it here, we were successful, break
+            break
+
         except Exception as err:
             if try_nr < 2:
                 print str(err), 'Retrying.'
                 os.remove(path)
+                # If we had an exception, this is where we need to increase
+                # our count retry
+                try_nr += 1
             else:
                 raise
-        try_nr += 1
 
     return data
 

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -326,7 +326,7 @@ def history_info():
                 'humidity': float(day_info['humidity'])
             }
         except ValueError:
-            print "Error parsing JSON, maybe bad data from wunderground?"
+            self.add_status("Skipped wundergound data because of a parsing error")
 
     return result
 
@@ -344,12 +344,15 @@ def today_info():
 
     day_info = data['current_observation']
 
-    result = {
-        'temp_c': float(day_info['temp_c']),
-        'rain_mm': float(day_info['precip_today_metric']),
-        'wind_ms': float(day_info['wind_kph']) / 3.6,
-        'humidity': float(day_info['relative_humidity'].replace('%', ''))
-    }
+    try:
+        result = {
+            'temp_c': float(day_info['temp_c']),
+            'rain_mm': float(day_info['precip_today_metric']),
+            'wind_ms': float(day_info['wind_kph']) / 3.6,
+            'humidity': float(day_info['relative_humidity'].replace('%', ''))
+        }
+    except ValueError:
+        self.add_status("Skipped wundergound data because of a parsing error")
 
     return result
 
@@ -374,11 +377,14 @@ def forecast_info():
     result = {}
     for index, day_info in info.iteritems():
         if index <= int(options['days_forecast']):
-            result[index] = {
-                'temp_c': float(day_info['high']['celsius']),
-                'rain_mm': float(day_info['qpf_allday']['mm']),
-                'wind_ms': float(day_info['avewind']['kph']) / 3.6,
-                'humidity': float(day_info['avehumidity'])
-            }
+            try:
+                result[index] = {
+                    'temp_c': float(day_info['high']['celsius']),
+                    'rain_mm': float(day_info['qpf_allday']['mm']),
+                    'wind_ms': float(day_info['avewind']['kph']) / 3.6,
+                    'humidity': float(day_info['avehumidity'])
+                }
+            except ValueError:
+                self.add_status("Skipped wundergound data because of a parsing error")
 
     return result

--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -148,7 +148,7 @@ class WeatherLevelChecker(Thread):
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 err_string = ''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))
                 self.add_status('Weather-base water level encountered error:\n' + err_string)
-                self._sleep(60)
+                self._sleep(3600)
             time.sleep(0.5)
 
 checker = WeatherLevelChecker()


### PR DESCRIPTION
After fixing a previous bug that caused my API usage to go through the roof, I had another instance.  The JSON data returned from wunderground can return "--" for some values that are expected as integer/float values.  Since python isn't strongly typed, this caused casts of those variables to fail.

One commit here is to skip bad data.

Another commit here is to sleep an hour even on failures instead of 60 seconds.  This was causing the API overages for my free account unnecessarily.

The third commit is to fix a bug found when debugging.  We call the API twice per request, even on a successful return.  The bug fix breaks out of the 2-retry loop upon success as well as moves the increment in the exception handler loop so we retry one time after a failure as expected.