### PR TITLE
Fix for Issue #105.

### DIFF
--- a/weather_level_adj/weather_level_adj.py
+++ b/weather_level_adj/weather_level_adj.py
@@ -222,6 +222,8 @@ def get_wunderground_lid():
         data = json.load(data)
         if data is None:
             return ""
+        elif len(data['RESULTS']) == 0:
+            return ""
         lid = "zmw:" + data['RESULTS'][0]['zmw']
 
     return lid


### PR DESCRIPTION
This is a fix for a call that returns an empty string for "lid" when there is
a successful call to wunderground with no valid data in the response.

This still causes an exception, but one that is caught instead of causing a
crash of ospi.

I'm not sure what is gained by this besides a cleaner error message, which,
I guess, is an improvement.